### PR TITLE
fix: make sure npm is enabled only if package-lock.json is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ public class ExhortExample {
         
         // get a AnalysisReport future holding a deserialized Component Analysis report
         var manifestContent = Files.readAllBytes(Paths.get("/path/to/pom.xml"));
-        CompletableFuture<AnalysisReport> componentReport = exhortApi.componentAnalysis("pom.xml", manifestContent);
+        CompletableFuture<AnalysisReport> componentReport = exhortApi.componentAnalysis("pom.xml", manifestContent, Paths.get("/path/to/pom.xml"));
     }
 }
 ```

--- a/src/main/java/com/redhat/exhort/Api.java
+++ b/src/main/java/com/redhat/exhort/Api.java
@@ -18,6 +18,7 @@ package com.redhat.exhort;
 import com.redhat.exhort.api.AnalysisReport;
 import com.redhat.exhort.image.ImageRef;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -104,8 +105,8 @@ public interface Api {
    * @return the deserialized Json report as an AnalysisReport wrapped in a CompletableFuture
    * @throws IOException when failed to load the manifest content
    */
-  CompletableFuture<AnalysisReport> componentAnalysis(String manifestType, byte[] manifestContent)
-      throws IOException;
+  CompletableFuture<AnalysisReport> componentAnalysis(
+      String manifestType, byte[] manifestContent, Path manifestPath) throws IOException;
 
   CompletableFuture<AnalysisReport> componentAnalysis(String manifestFile) throws IOException;
 

--- a/src/main/java/com/redhat/exhort/impl/ExhortApi.java
+++ b/src/main/java/com/redhat/exhort/impl/ExhortApi.java
@@ -39,6 +39,7 @@ import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -420,9 +421,10 @@ public final class ExhortApi implements Api {
 
   @Override
   public CompletableFuture<AnalysisReport> componentAnalysis(
-      final String manifestType, final byte[] manifestContent) throws IOException {
+      final String manifestType, final byte[] manifestContent, final Path manifestPath)
+      throws IOException {
     String exClientTraceId = commonHookBeginning(false);
-    var provider = Ecosystem.getProvider(manifestType);
+    var provider = Ecosystem.getProvider(manifestType, manifestPath);
     var uri = URI.create(String.format("%s/api/v4/analysis", this.endpoint));
     var content = provider.provideComponent(manifestContent);
     commonHookAfterProviderCreatedSbomAndBeforeExhort();

--- a/src/main/java/com/redhat/exhort/tools/Ecosystem.java
+++ b/src/main/java/com/redhat/exhort/tools/Ecosystem.java
@@ -21,6 +21,7 @@ import com.redhat.exhort.providers.GradleProvider;
 import com.redhat.exhort.providers.JavaMavenProvider;
 import com.redhat.exhort.providers.JavaScriptNpmProvider;
 import com.redhat.exhort.providers.PythonPipProvider;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /** Utility class used for instantiating providers. * */
@@ -55,7 +56,7 @@ public final class Ecosystem {
    * @return a Manifest record
    */
   public static Provider getProvider(final Path manifestPath) {
-    return Ecosystem.getProvider(manifestPath.getFileName().toString());
+    return Ecosystem.getProvider(manifestPath.getFileName().toString(), manifestPath);
   }
 
   /**
@@ -64,12 +65,18 @@ public final class Ecosystem {
    * @param manifestType the type (filename + type) of the manifest
    * @return a Manifest record
    */
-  public static Provider getProvider(final String manifestType) {
+  public static Provider getProvider(final String manifestType, final Path manifestPath) {
     switch (manifestType) {
       case "pom.xml":
         return new JavaMavenProvider();
       case "package.json":
-        return new JavaScriptNpmProvider();
+        Path lockFile = manifestPath.getParent().resolve("package-lock.json");
+        if (Files.exists(lockFile)) {
+          return new JavaScriptNpmProvider();
+        } else {
+          throw new IllegalStateException(
+              String.format("NPM Lock file could not be found for %s", manifestType));
+        }
       case "go.mod":
         return new GoModulesProvider();
       case "requirements.txt":

--- a/src/test/java/com/redhat/exhort/ExhortTest.java
+++ b/src/test/java/com/redhat/exhort/ExhortTest.java
@@ -15,11 +15,17 @@
  */
 package com.redhat.exhort;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.commons.io.FileUtils;
 
 public class ExhortTest {
 
@@ -36,8 +42,8 @@ public class ExhortTest {
     return new String(bytes);
   }
 
-  public static InputStream getResourceAsStreamDecision(
-      Class<? extends ExhortTest> theClass, String[] list) throws IOException {
+  public static InputStream getResourceAsStreamDecision(Class theClass, String[] list)
+      throws IOException {
     InputStream resourceAsStreamFromModule =
         theClass.getModule().getResourceAsStream(String.join("/", list));
     if (Objects.isNull(resourceAsStreamFromModule)) {
@@ -67,6 +73,74 @@ public class ExhortTest {
       throw new RuntimeException(e);
     }
     return tmpFile.toString();
+  }
+
+  public static class TempDirFromResources {
+    private final Path tmpDir;
+
+    public TempDirFromResources() throws IOException {
+      tmpDir = Files.createTempDirectory("exhort_test_");
+    }
+
+    public class AddPath {
+      private final String fileName;
+
+      public AddPath(String fileName) {
+        this.fileName = fileName;
+      }
+
+      public TempDirFromResources fromResources(String... pathList) {
+        Path tmpFile;
+        try {
+          tmpFile = Files.createFile(tmpDir.resolve(this.fileName));
+          try (var is = getResourceAsStreamDecision(super.getClass(), pathList)) {
+            if (Objects.nonNull(is)) {
+              Files.write(tmpFile, is.readAllBytes());
+            } else {
+              InputStream resourceIs =
+                  getClass().getClassLoader().getResourceAsStream(String.join("/", pathList));
+              Files.write(tmpFile, resourceIs.readAllBytes());
+              resourceIs.close();
+            }
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        return TempDirFromResources.this;
+      }
+    }
+
+    public AddPath addFile(String fileName) {
+      return new AddPath(fileName);
+    }
+
+    public TempDirFromResources addDirectory(String dirName, String... pathList) {
+      File target = this.tmpDir.resolve(dirName).toFile();
+      String join = String.join("/", pathList);
+      URL resource = this.getClass().getClassLoader().getResource(join);
+      File source = new File(Objects.requireNonNull(resource).getFile());
+      try {
+        FileUtils.copyDirectory(source, target);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return this;
+    }
+
+    public TempDirFromResources addFile(
+        Optional<String> fileName, Supplier<List<String>> pathList) {
+      if (fileName.isEmpty()) {
+        return this;
+      }
+
+      return new AddPath(fileName.get()).fromResources(pathList.get().toArray(new String[0]));
+    }
+
+    public Path getTempDir() {
+      return this.tmpDir;
+    }
   }
 
   protected String getFileFromString(String fileName, String content) {


### PR DESCRIPTION
## Description

This change should be the counter part of https://github.com/trustification/exhort-javascript-api/pull/151
which will avoid npm projects being analyzed unless the owner of the code has the file package-lock.json.

In order to detect whether or not there is a package-lock.json file next to the manifest file (package.json), an additional parameter needs to be passed to the `exhortApi` . The additional param is the directory path where the manifest file lies.
## Checklist

- [ ] I have followed this repository's contributing guidelines.
- [ ] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
