### PR TITLE
fix: fix incorrect pathEnv() implementation in JavaScriptProvider subclass

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/JavaScriptNpmProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptNpmProvider.java
@@ -26,7 +26,6 @@ public final class JavaScriptNpmProvider extends JavaScriptProvider {
 
   public static final String LOCK_FILE = "package-lock.json";
   public static final String CMD_NAME = "npm";
-  public static final String ENV_NODE_HOME = "NODE_HOME";
 
   public JavaScriptNpmProvider(Path manifest) {
     super(manifest, Ecosystem.Type.NPM, CMD_NAME);
@@ -35,11 +34,6 @@ public final class JavaScriptNpmProvider extends JavaScriptProvider {
   @Override
   protected final String lockFileName() {
     return LOCK_FILE;
-  }
-
-  @Override
-  protected String pathEnv() {
-    return ENV_NODE_HOME;
   }
 
   @Override

--- a/src/main/java/com/redhat/exhort/providers/JavaScriptPnpmProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptPnpmProvider.java
@@ -29,7 +29,6 @@ public final class JavaScriptPnpmProvider extends JavaScriptProvider {
 
   public static final String LOCK_FILE = "pnpm-lock.yaml";
   public static final String CMD_NAME = "pnpm";
-  public static final String ENV_PNPM_HOME = "PNPM_HOME";
 
   public JavaScriptPnpmProvider(Path manifest) {
     super(manifest, Ecosystem.Type.PNPM, CMD_NAME);
@@ -38,11 +37,6 @@ public final class JavaScriptPnpmProvider extends JavaScriptProvider {
   @Override
   protected final String lockFileName() {
     return LOCK_FILE;
-  }
-
-  @Override
-  protected String pathEnv() {
-    return ENV_PNPM_HOME;
   }
 
   @Override

--- a/src/main/java/com/redhat/exhort/providers/JavaScriptProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptProvider.java
@@ -50,6 +50,7 @@ import java.util.TreeMap;
  */
 public abstract class JavaScriptProvider extends Provider {
 
+  public static final String ENV_NODE_HOME = "NODE_HOME";
   private static final String PROP_PATH = "PATH";
 
   private System.Logger log = System.getLogger(this.getClass().getName());
@@ -73,7 +74,9 @@ public abstract class JavaScriptProvider extends Provider {
 
   protected abstract String lockFileName();
 
-  protected abstract String pathEnv();
+  protected String pathEnv() {
+    return ENV_NODE_HOME;
+  }
 
   protected abstract String[] updateLockFileCmd(Path manifestDir);
 

--- a/src/main/java/com/redhat/exhort/providers/JavaScriptYarnProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptYarnProvider.java
@@ -34,7 +34,6 @@ public final class JavaScriptYarnProvider extends JavaScriptProvider {
 
   public static final String LOCK_FILE = "yarn.lock";
   public static final String CMD_NAME = "yarn";
-  public static final String ENV_YARN_HOME = "YARN_HOME";
 
   private static final Pattern versionPattern = Pattern.compile("^([0-9]+)\\.");
 
@@ -48,11 +47,6 @@ public final class JavaScriptYarnProvider extends JavaScriptProvider {
   @Override
   protected final String lockFileName() {
     return LOCK_FILE;
-  }
-
-  @Override
-  protected String pathEnv() {
-    return ENV_YARN_HOME;
   }
 
   @Override


### PR DESCRIPTION
## Description

fix: fix incorrect pathEnv() implementation in JavaScriptProvider subclass
see more info in the bug report https://github.com/trustification/exhort-java-api/issues/132

**Related issue (if any):** fixes https://github.com/trustification/exhort-java-api/issues/132
## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
