### PR TITLE
fix: validate executable binary in the path before running the analysis.

### DIFF
--- a/src/main/java/com/redhat/exhort/image/ImageUtils.java
+++ b/src/main/java/com/redhat/exhort/image/ImageUtils.java
@@ -55,6 +55,12 @@ public class ImageUtils {
       "application/vnd.oci.image.manifest.v1+json";
   private static final String MEDIA_TYPE_OCI1_MANIFEST_LIST =
       "application/vnd.oci.image.index.v1+json";
+  private static final String DOCKER = "docker";
+  private static final String PODMAN = "podman";
+  private static final String SYFT = "syft";
+  private static final String SKOPEO = "skopeo";
+  public static final String SKIP_VALIDATION_KEY = "skip.binary.validation";
+  public static final String ARG_VERSION = "--version";
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -124,9 +130,9 @@ public class ImageUtils {
   }
 
   static Operations.ProcessExecOutput execSyft(ImageRef imageRef) {
-    var syft = Operations.getCustomPathOrElse("syft");
-    var docker = Operations.getCustomPathOrElse("docker");
-    var podman = Operations.getCustomPathOrElse("podman");
+    var syft = Operations.getExecutable(SYFT, ARG_VERSION);
+    var docker = Operations.getExecutable(DOCKER, ARG_VERSION);
+    var podman = Operations.getExecutable(PODMAN, ARG_VERSION);
 
     var syftConfigPath = Environment.get(EXHORT_SYFT_CONFIG_PATH, "");
     var imageSource = Environment.get(EXHORT_SYFT_IMAGE_SOURCE, "");
@@ -232,7 +238,7 @@ public class ImageUtils {
   }
 
   static String hostInfo(String engine, String info) {
-    var exec = Operations.getCustomPathOrElse(engine);
+    var exec = Operations.getExecutable(engine, ARG_VERSION);
     var cmd = new String[] {exec, "info"};
 
     var output = Operations.runProcessGetFullOutput(null, cmd, null);
@@ -251,31 +257,31 @@ public class ImageUtils {
   }
 
   static String dockerGetOs() {
-    return hostInfo("docker", "OSType");
+    return hostInfo(DOCKER, "OSType");
   }
 
   static String dockerGetArch() {
-    var arch = hostInfo("docker", "Architecture");
+    var arch = hostInfo(DOCKER, "Architecture");
     arch = archMapping.get(arch);
     return Objects.requireNonNullElse(arch, "");
   }
 
   static String dockerGetVariant() {
-    var variant = hostInfo("docker", "Architecture");
+    var variant = hostInfo(DOCKER, "Architecture");
     variant = variantMapping.get(variant);
     return Objects.requireNonNullElse(variant, "");
   }
 
   static String podmanGetOs() {
-    return hostInfo("podman", "os");
+    return hostInfo(PODMAN, "os");
   }
 
   static String podmanGetArch() {
-    return hostInfo("podman", "arch");
+    return hostInfo(PODMAN, "arch");
   }
 
   static String podmanGetVariant() {
-    return hostInfo("podman", "variant");
+    return hostInfo(PODMAN, "variant");
   }
 
   static String dockerPodmanInfo(Supplier<String> dockerSupplier, Supplier<String> podmanSupplier) {
@@ -416,7 +422,7 @@ public class ImageUtils {
   }
 
   static Operations.ProcessExecOutput execSkopeoInspect(ImageRef imageRef, boolean raw) {
-    var skopeo = Operations.getCustomPathOrElse("skopeo");
+    var skopeo = Operations.getExecutable(SKOPEO, ARG_VERSION);
 
     var configPath = Environment.get(EXHORT_SKOPEO_CONFIG_PATH, "");
     var daemonHost = Environment.get(EXHORT_IMAGE_SERVICE_ENDPOINT, "");

--- a/src/main/java/com/redhat/exhort/providers/GradleProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/GradleProvider.java
@@ -29,7 +29,12 @@ import com.redhat.exhort.tools.Operations;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -49,7 +54,9 @@ public final class GradleProvider extends BaseJavaProvider {
   public static final String[] COMPONENT_ANALYSIS_CONFIGURATIONS = {
     "api", "implementation", "compileOnlyApi", "compileOnly", "runtimeOnly"
   };
-  private Logger log = LoggersFactory.getLogger(this.getClass().getName());
+  private static final Logger log = LoggersFactory.getLogger(GradleProvider.class.getName());
+
+  private final String gradleExecutable = Operations.getExecutable("gradle", "--version");
 
   public GradleProvider(Path manifest) {
     super(Type.GRADLE, manifest);
@@ -213,12 +220,10 @@ public final class GradleProvider extends BaseJavaProvider {
   }
 
   private Path getDependencies(Path manifestPath) throws IOException {
-    // check for custom gradle executable
-    var gradle = Operations.getCustomPathOrElse("gradle");
     // create a temp file for storing the dependency tree in
     var tempFile = Files.createTempFile("exhort_graph_", null);
     // the command will create the dependency tree in the temp file
-    String gradleCommand = gradle + " dependencies";
+    String gradleCommand = gradleExecutable + " dependencies";
 
     String[] cmdList = gradleCommand.split("\\s+");
     String gradleOutput =
@@ -228,10 +233,9 @@ public final class GradleProvider extends BaseJavaProvider {
     return tempFile;
   }
 
-  private Path getProperties(Path manifestPath) throws IOException {
+  protected Path getProperties(Path manifestPath) throws IOException {
     Path propsTempFile = Files.createTempFile("propsfile", ".txt");
-    var gradle = Operations.getCustomPathOrElse("gradle");
-    String propCmd = gradle + " properties";
+    String propCmd = gradleExecutable + " properties";
     String[] propCmdList = propCmd.split("\\s+");
     String properties =
         Operations.runProcessGetOutput(Path.of(manifestPath.getParent().toString()), propCmdList);

--- a/src/main/java/com/redhat/exhort/tools/Ecosystem.java
+++ b/src/main/java/com/redhat/exhort/tools/Ecosystem.java
@@ -41,6 +41,27 @@ public final class Ecosystem {
       return type;
     }
 
+    public String getExecutableShortName() {
+      switch (this) {
+        case MAVEN:
+          return "mvn";
+        case NPM:
+          return "npm";
+        case PNPM:
+          return "pnpm";
+        case YARN:
+          return "yarn";
+        case GOLANG:
+          return "go";
+        case PYTHON:
+          return "python";
+        case GRADLE:
+          return "gradle";
+        default:
+          throw new IllegalStateException("Unexpected value: " + this);
+      }
+    }
+
     Type(String type) {
       this.type = type;
     }

--- a/src/test/java/com/redhat/exhort/image/ImageRefTest.java
+++ b/src/test/java/com/redhat/exhort/image/ImageRefTest.java
@@ -18,6 +18,7 @@ package com.redhat.exhort.image;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 
@@ -77,6 +78,8 @@ class ImageRefTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
 
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -89,6 +92,8 @@ class ImageRefTest extends ExhortTest {
           .thenReturn(output);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn("docker");
+
+      mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn("docker");
 
       mock.when(
               () ->

--- a/src/test/java/com/redhat/exhort/image/ImageUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/image/ImageUtilsTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 
@@ -51,6 +52,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -79,6 +82,8 @@ class ImageUtilsTest extends ExhortTest {
   static final String mockOs = "linux";
   static final String mockArch = "arm";
   static final String mockVariant = "v7";
+
+  private static final String SKIP_VALIDATION_KEY = "skip.binary.validation";
 
   static Stream<Arguments> dockerArchSources() {
     return Stream.of(
@@ -116,6 +121,16 @@ class ImageUtilsTest extends ExhortTest {
         Arguments.of(Named.of("empty", ""), ""));
   }
 
+  @BeforeEach
+  void setUp() {
+    System.setProperty(SKIP_VALIDATION_KEY, "true");
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(SKIP_VALIDATION_KEY);
+  }
+
   @Test
   @ClearSystemProperty(key = "PATH")
   @ClearSystemProperty(key = "EXHORT_SYFT_PATH")
@@ -133,6 +148,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput(json, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("syft"))).thenReturn("syft");
+
+      mock.when(() -> Operations.getExecutable(eq("syft"), any())).thenReturn("syft");
 
       mock.when(
               () ->
@@ -180,6 +197,8 @@ class ImageUtilsTest extends ExhortTest {
       var outputRaw = new Operations.ProcessExecOutput(jsonRaw, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
+
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
 
       mock.when(
               () ->
@@ -242,6 +261,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput(json, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
+
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
 
       mock.when(
               () ->
@@ -309,6 +330,8 @@ class ImageUtilsTest extends ExhortTest {
     try (MockedStatic<Operations> mock = Mockito.mockStatic(Operations.class)) {
       mock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn("podman");
 
+      mock.when(() -> Operations.getExecutable(eq("podman"), any())).thenReturn("podman");
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -330,6 +353,8 @@ class ImageUtilsTest extends ExhortTest {
   void test_get_image_platform_no_defaults() {
     try (MockedStatic<Operations> mock = Mockito.mockStatic(Operations.class)) {
       mock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn("podman");
+
+      mock.when(() -> Operations.getExecutable(eq("podman"), any())).thenReturn("podman");
 
       mock.when(
               () ->
@@ -355,9 +380,19 @@ class ImageUtilsTest extends ExhortTest {
 
         opsMock.when(() -> Operations.getCustomPathOrElse(eq("syft"))).thenReturn(mockSyftPath);
 
+        opsMock.when(() -> Operations.getExecutable(eq("syft"), any())).thenReturn(mockSyftPath);
+
         opsMock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn(mockDockerPath);
 
+        opsMock
+            .when(() -> Operations.getExecutable(eq("docker"), any()))
+            .thenReturn(mockDockerPath);
+
         opsMock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn(mockPodmanPath);
+
+        opsMock
+            .when(() -> Operations.getExecutable(eq("podman"), any()))
+            .thenReturn(mockPodmanPath);
 
         opsMock
             .when(
@@ -401,9 +436,15 @@ class ImageUtilsTest extends ExhortTest {
 
         mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn("docker");
 
+        mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn("docker");
+
         mock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn("podman");
 
+        mock.when(() -> Operations.getExecutable(eq("podman"), any())).thenReturn("podman");
+
         mock.when(() -> Operations.getCustomPathOrElse(eq("syft"))).thenReturn("syft");
+
+        mock.when(() -> Operations.getExecutable(eq("syft"), any())).thenReturn("syft");
 
         mock.when(
                 () ->
@@ -476,6 +517,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn(mockDockerPath);
 
+      mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn(mockDockerPath);
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -493,6 +536,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("", "test-error", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn("docker");
+
+      mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn("docker");
 
       mock.when(
               () ->
@@ -519,6 +564,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn(mockDockerPath);
 
+      mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn(mockDockerPath);
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -538,6 +585,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("Architecture:" + sysArch, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn(mockDockerPath);
+
+      mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn(mockDockerPath);
 
       mock.when(
               () ->
@@ -559,6 +608,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn(mockDockerPath);
 
+      mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn(mockDockerPath);
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -577,6 +628,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("info: test-output\nabcdesss", "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn(mockPodmanPath);
+
+      mock.when(() -> Operations.getExecutable(eq("podman"), any())).thenReturn(mockPodmanPath);
 
       mock.when(
               () ->
@@ -597,6 +650,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn(mockPodmanPath);
 
+      mock.when(() -> Operations.getExecutable(eq("podman"), any())).thenReturn(mockPodmanPath);
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -616,6 +671,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn(mockPodmanPath);
 
+      mock.when(() -> Operations.getExecutable(eq("podman"), any())).thenReturn(mockPodmanPath);
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -634,6 +691,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("variant: test-output", "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("podman"))).thenReturn(mockPodmanPath);
+
+      mock.when(() -> Operations.getExecutable(eq("podman"), any())).thenReturn(mockPodmanPath);
 
       mock.when(
               () ->
@@ -663,6 +722,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("test-output", "test-error", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn(mockSkopeoPath);
+
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn(mockSkopeoPath);
 
       mock.when(
               () ->
@@ -696,6 +757,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn(mockSkopeoPath);
 
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn(mockSkopeoPath);
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -725,6 +788,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("test-output", "test-error", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
+
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
 
       mock.when(
               () ->
@@ -756,6 +821,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
 
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -783,6 +850,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("test-output", "test-error", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn(mockSkopeoPath);
+
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn(mockSkopeoPath);
 
       mock.when(
               () ->
@@ -816,6 +885,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn(mockSkopeoPath);
 
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn(mockSkopeoPath);
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -846,6 +917,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
 
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -875,6 +948,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput("test-output", "test-error", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
+
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
 
       mock.when(
               () ->
@@ -976,6 +1051,8 @@ class ImageUtilsTest extends ExhortTest {
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
 
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
+
       mock.when(
               () ->
                   Operations.runProcessGetFullOutput(
@@ -1008,6 +1085,8 @@ class ImageUtilsTest extends ExhortTest {
       var output = new Operations.ProcessExecOutput(mapper.writeValueAsString(node), "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("skopeo"))).thenReturn("skopeo");
+
+      mock.when(() -> Operations.getExecutable(eq("skopeo"), any())).thenReturn("skopeo");
 
       mock.when(
               () ->

--- a/src/test/java/com/redhat/exhort/impl/ExhortApiIT.java
+++ b/src/test/java/com/redhat/exhort/impl/ExhortApiIT.java
@@ -16,6 +16,7 @@
 package com.redhat.exhort.impl;
 
 import static com.redhat.exhort.Provider.PROP_MATCH_MANIFEST_VERSIONS;
+import static com.redhat.exhort.image.ImageUtils.SKIP_VALIDATION_KEY;
 import static com.redhat.exhort.utils.PythonControllerBase.PROP_EXHORT_PYTHON_INSTALL_BEST_EFFORTS;
 import static com.redhat.exhort.utils.PythonControllerBase.PROP_EXHORT_PYTHON_VIRTUAL_ENV;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mockStatic;
@@ -240,6 +242,7 @@ class ExhortApiIT extends ExhortTest {
 
   @Tag("IntegrationTest")
   @Test
+  @SetSystemProperty(key = SKIP_VALIDATION_KEY, value = "true")
   void Integration_Test_End_To_End_Image_Analysis() throws IOException {
     var result =
         testImageAnalysis(
@@ -257,6 +260,7 @@ class ExhortApiIT extends ExhortTest {
 
   @Tag("IntegrationTest")
   @Test
+  @SetSystemProperty(key = SKIP_VALIDATION_KEY, value = "true")
   void Integration_Test_End_To_End_Image_Analysis_Html() throws IOException {
     var result =
         testImageAnalysis(
@@ -288,6 +292,8 @@ class ExhortApiIT extends ExhortTest {
       var output = new Operations.ProcessExecOutput(jsonSbom, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("syft"))).thenReturn("syft");
+
+      mock.when(() -> Operations.getExecutable(eq("syft"), any())).thenReturn("syft");
 
       mock.when(
               () ->
@@ -365,6 +371,12 @@ class ExhortApiIT extends ExhortTest {
                 return getOutputFileAndOverwriteItWithMock(
                     depTree, invocationOnMock, "-DoutputFile");
               });
+      mockedOperations
+          .when(() -> Operations.getCustomPathOrElse(anyString()))
+          .thenReturn(packageManager.getExecutableShortName());
+      mockedOperations
+          .when(() -> Operations.getExecutable(anyString(), anyString()))
+          .thenReturn(packageManager.getExecutableShortName());
     }
   }
 

--- a/src/test/java/com/redhat/exhort/impl/Exhort_Api_Test.java
+++ b/src/test/java/com/redhat/exhort/impl/Exhort_Api_Test.java
@@ -15,6 +15,7 @@
  */
 package com.redhat.exhort.impl;
 
+import static com.redhat.exhort.image.ImageUtils.SKIP_VALIDATION_KEY;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -86,6 +87,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ClearSystemProperty(key = "RHDA_SOURCE")
 @SuppressWarnings("unchecked")
 class Exhort_Api_Test extends ExhortTest {
+
   @Mock Provider mockProvider;
 
   @Mock HttpClient mockHttpClient;
@@ -457,6 +459,7 @@ class Exhort_Api_Test extends ExhortTest {
   @SetSystemProperty(key = "EXHORT_SNYK_TOKEN", value = "snyk-token-from-env-var")
   @SetSystemProperty(key = "RHDA_TOKEN", value = "rhda-token-from-env-var")
   @SetSystemProperty(key = "RHDA_SOURCE", value = "rhda-source-from-env-var")
+  @SetSystemProperty(key = SKIP_VALIDATION_KEY, value = "true")
   void test_image_analysis()
       throws IOException, ExecutionException, InterruptedException, MalformedPackageURLException {
     try (MockedStatic<Operations> mock = Mockito.mockStatic(Operations.class);
@@ -476,6 +479,8 @@ class Exhort_Api_Test extends ExhortTest {
       var output = new Operations.ProcessExecOutput(jsonSbom, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("syft"))).thenReturn("syft");
+
+      mock.when(() -> Operations.getExecutable(eq("syft"), any())).thenReturn("syft");
 
       mock.when(
               () ->
@@ -554,6 +559,7 @@ class Exhort_Api_Test extends ExhortTest {
   @SetSystemProperty(key = "EXHORT_SNYK_TOKEN", value = "snyk-token-from-env-var")
   @SetSystemProperty(key = "RHDA_TOKEN", value = "rhda-token-from-env-var")
   @SetSystemProperty(key = "RHDA_SOURCE", value = "rhda-source-from-env-var")
+  @SetSystemProperty(key = SKIP_VALIDATION_KEY, value = "true")
   void imageAnalysisHtml()
       throws IOException, ExecutionException, InterruptedException, MalformedPackageURLException {
     try (MockedStatic<Operations> mock = Mockito.mockStatic(Operations.class);
@@ -573,6 +579,8 @@ class Exhort_Api_Test extends ExhortTest {
       var output = new Operations.ProcessExecOutput(jsonSbom, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("syft"))).thenReturn("syft");
+
+      mock.when(() -> Operations.getExecutable(eq("syft"), any())).thenReturn("syft");
 
       mock.when(
               () ->
@@ -688,6 +696,7 @@ class Exhort_Api_Test extends ExhortTest {
   }
 
   @Test
+  @SetSystemProperty(key = SKIP_VALIDATION_KEY, value = "true")
   void test_get_batch_image_sboms() throws IOException, MalformedPackageURLException {
     try (MockedStatic<Operations> mock = Mockito.mockStatic(Operations.class);
         var is = getResourceAsStreamDecision(this.getClass(), "msc/image/image_sbom.json")) {
@@ -703,6 +712,8 @@ class Exhort_Api_Test extends ExhortTest {
       var output = new Operations.ProcessExecOutput(json, "", 0);
 
       mock.when(() -> Operations.getCustomPathOrElse(eq("syft"))).thenReturn("syft");
+
+      mock.when(() -> Operations.getExecutable(eq("syft"), any())).thenReturn("syft");
 
       mock.when(
               () ->

--- a/src/test/java/com/redhat/exhort/providers/Gradle_Provider_Test.java
+++ b/src/test/java/com/redhat/exhort/providers/Gradle_Provider_Test.java
@@ -132,6 +132,9 @@ abstract class Gradle_Provider_Test extends ExhortTest {
     try (MockedStatic<Operations> mockedOperations = mockStatic(Operations.class)) {
       mockedOperations.when(() -> Operations.getCustomPathOrElse("gradle")).thenReturn("gradle");
       mockedOperations
+          .when(() -> Operations.getExecutable("gradle", "--version"))
+          .thenReturn("gradle");
+      mockedOperations
           .when(
               () ->
                   Operations.runProcessGetOutput(
@@ -231,6 +234,9 @@ abstract class Gradle_Provider_Test extends ExhortTest {
       ArgumentMatcher<String> dependencies = string -> string.equals("dependencies");
       ArgumentMatcher<String> properties = string -> string.equals("properties");
       mockedOperations.when(() -> Operations.getCustomPathOrElse("gradle")).thenReturn("gradle");
+      mockedOperations
+          .when(() -> Operations.getExecutable("gradle", "--version"))
+          .thenReturn("gradle");
       mockedOperations
           .when(
               () ->

--- a/src/test/java/com/redhat/exhort/providers/Java_Maven_Provider_Test.java
+++ b/src/test/java/com/redhat/exhort/providers/Java_Maven_Provider_Test.java
@@ -17,6 +17,7 @@ package com.redhat.exhort.providers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 
 import com.redhat.exhort.Api;
@@ -89,6 +90,11 @@ public class Java_Maven_Provider_Test extends ExhortTest {
                 return getOutputFileAndOverwriteItWithMock(
                     depTree, invocationOnMock, "-DoutputFile");
               });
+      // Mock Operations.getCustomPathOrElse to return "mvn"
+      mockedOperations.when(() -> Operations.getCustomPathOrElse(anyString())).thenReturn("mvn");
+      mockedOperations
+          .when(() -> Operations.getExecutable(anyString(), anyString()))
+          .thenReturn("mvn");
 
       // when providing stack content for our pom
       var content = new JavaMavenProvider(tmpPomFile).provideStack();
@@ -146,6 +152,11 @@ public class Java_Maven_Provider_Test extends ExhortTest {
                 return getOutputFileAndOverwriteItWithMock(
                     effectivePom, invocationOnMock, "-Doutput");
               });
+      // Mock Operations.getCustomPathOrElse to return "mvn"
+      mockedOperations.when(() -> Operations.getCustomPathOrElse(anyString())).thenReturn("mvn");
+      mockedOperations
+          .when(() -> Operations.getExecutable(anyString(), anyString()))
+          .thenReturn("mvn");
 
       // when providing component content for our pom
       var content = new JavaMavenProvider(targetPom).provideComponent();
@@ -190,6 +201,11 @@ public class Java_Maven_Provider_Test extends ExhortTest {
                 return getOutputFileAndOverwriteItWithMock(
                     effectivePom, invocationOnMock, "-Doutput");
               });
+      // Mock Operations.getCustomPathOrElse to return "mvn"
+      mockedOperations.when(() -> Operations.getCustomPathOrElse(anyString())).thenReturn("mvn");
+      mockedOperations
+          .when(() -> Operations.getExecutable(anyString(), anyString()))
+          .thenReturn("mvn");
 
       // when providing component content for our pom
       var content = new JavaMavenProvider(tmpPomFile).provideComponent();

--- a/src/test/java/com/redhat/exhort/providers/Javascript_Provider_Test.java
+++ b/src/test/java/com/redhat/exhort/providers/Javascript_Provider_Test.java
@@ -233,8 +233,17 @@ class Javascript_Provider_Test extends ExhortTest {
           .thenReturn(listResult);
     }
 
+    // Mock for yarn
+    mockedOperations.when(() -> Operations.getCustomPathOrElse(eq("yarn"))).thenReturn("yarn");
+    mockedOperations
+        .when(() -> Operations.getExecutable(eq("yarn"), anyString()))
+        .thenReturn("yarn");
+    // Mock for other pkgManager values (return pkgManager as-is)
     mockedOperations
         .when(() -> Operations.getCustomPathOrElse(eq(pkgManager)))
+        .thenReturn(pkgManager);
+    mockedOperations
+        .when(() -> Operations.getExecutable(eq(pkgManager), any()))
         .thenReturn(pkgManager);
     return mockedOperations;
   }


### PR DESCRIPTION
## Description

fix: validate executable binary in the path before running the analysis.

**Related issue (if any):** https://github.com/redhat-developer/intellij-dependency-analytics/issues/182

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
