### PR TITLE
fix: add necessary envs (if has) to validate executable binary in the PATH

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/JavaScriptProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptProvider.java
@@ -62,7 +62,7 @@ public abstract class JavaScriptProvider extends Provider {
 
   public JavaScriptProvider(Path manifest, Ecosystem.Type ecosystem, String cmd) {
     super(ecosystem, manifest);
-    this.cmd = Operations.getExecutable(cmd, "-v");
+    this.cmd = Operations.getExecutable(cmd, "-v", getExecEnv());
     try {
       this.manifest = new Manifest(manifest);
     } catch (IOException e) {

--- a/src/main/java/com/redhat/exhort/tools/Operations.java
+++ b/src/main/java/com/redhat/exhort/tools/Operations.java
@@ -242,10 +242,17 @@ public final class Operations {
    * @throws RuntimeException if the executable cannot be found, is not executable, or exits with an
    *     error code
    */
-  public static String getExecutable(String command, String args) {
+  public static String getExecutable(
+      String command, String args, final Map<String, String> envMap) {
     String cmdExecutable = Operations.getCustomPathOrElse(command);
     try {
-      Process process = new ProcessBuilder(cmdExecutable, args).redirectErrorStream(true).start();
+      ProcessBuilder processBuilder = new ProcessBuilder();
+      processBuilder.command(cmdExecutable, args);
+      if (envMap != null) {
+        processBuilder.environment().putAll(envMap);
+      }
+      Process process = processBuilder.start();
+
       int exitCode = process.waitFor();
       if (exitCode != 0) {
         throw new IOException(
@@ -264,5 +271,9 @@ public final class Operations {
           e);
     }
     return cmdExecutable;
+  }
+
+  public static String getExecutable(String command, String args) {
+    return getExecutable(command, args, null);
   }
 }


### PR DESCRIPTION
## Description
fix: add necessary envs (if has) to validate executable binary in the PATH

**Related issue (if any):** amend the fix made in https://github.com/trustification/exhort-java-api/pull/134

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

