### PR TITLE
chore: update python test dependency immutables to be compitable with higher version python

### DIFF
--- a/src/test/resources/tst_manifests/pip/pip-freeze-all.txt
+++ b/src/test/resources/tst_manifests/pip/pip-freeze-all.txt
@@ -23,7 +23,7 @@ geopy==2.0.0
 greenlet==3.0.0
 h11==0.13.0
 idna==2.10
-immutables==0.19
+immutables==0.21
 importlib-metadata==4.8.3
 itsdangerous==2.0.1
 Jinja2==3.0.3

--- a/src/test/resources/tst_manifests/pip/pip-show.txt
+++ b/src/test/resources/tst_manifests/pip/pip-show.txt
@@ -197,7 +197,7 @@ Requires:
 Required-by: anyio, requests
 ---
 Name: immutables
-Version: 0.19
+Version: 0.21
 Summary: Immutable Collections
 Home-page: https://github.com/MagicStack/immutables
 Author: MagicStack Inc

--- a/src/test/resources/tst_manifests/pip/pip_requirements_txt_ignore/expected_component_sbom.json
+++ b/src/test/resources/tst_manifests/pip/pip_requirements_txt_ignore/expected_component_sbom.json
@@ -92,10 +92,10 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:pypi/immutables@0.19",
+      "bom-ref" : "pkg:pypi/immutables@0.21",
       "name" : "immutables",
-      "version" : "0.19",
-      "purl" : "pkg:pypi/immutables@0.19"
+      "version" : "0.21",
+      "purl" : "pkg:pypi/immutables@0.21"
     },
     {
       "type" : "library",
@@ -210,7 +210,7 @@
         "pkg:pypi/flask@2.0.3",
         "pkg:pypi/h11@0.13.0",
         "pkg:pypi/idna@2.10",
-        "pkg:pypi/immutables@0.19",
+        "pkg:pypi/immutables@0.21",
         "pkg:pypi/importlib-metadata@4.8.3",
         "pkg:pypi/itsdangerous@2.0.1",
         "pkg:pypi/jinja2@3.0.3",
@@ -268,7 +268,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:pypi/immutables@0.19",
+      "ref" : "pkg:pypi/immutables@0.21",
       "dependsOn" : [ ]
     },
     {

--- a/src/test/resources/tst_manifests/pip/pip_requirements_txt_ignore/expected_stack_sbom.json
+++ b/src/test/resources/tst_manifests/pip/pip_requirements_txt_ignore/expected_stack_sbom.json
@@ -148,10 +148,10 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:pypi/immutables@0.19",
+      "bom-ref" : "pkg:pypi/immutables@0.21",
       "name" : "immutables",
-      "version" : "0.19",
-      "purl" : "pkg:pypi/immutables@0.19"
+      "version" : "0.21",
+      "purl" : "pkg:pypi/immutables@0.21"
     },
     {
       "type" : "library",
@@ -210,7 +210,7 @@
         "pkg:pypi/flask@2.0.3",
         "pkg:pypi/h11@0.13.0",
         "pkg:pypi/idna@2.10",
-        "pkg:pypi/immutables@0.19",
+        "pkg:pypi/immutables@0.21",
         "pkg:pypi/importlib-metadata@4.8.3",
         "pkg:pypi/itsdangerous@2.0.1",
         "pkg:pypi/jinja2@3.0.3",
@@ -315,7 +315,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:pypi/immutables@0.19",
+      "ref" : "pkg:pypi/immutables@0.21",
       "dependsOn" : [ ]
     },
     {

--- a/src/test/resources/tst_manifests/pip/pip_requirements_txt_ignore/requirements.txt
+++ b/src/test/resources/tst_manifests/pip/pip_requirements_txt_ignore/requirements.txt
@@ -9,7 +9,7 @@ fastapi==0.75.1
 Flask==2.0.3
 h11==0.13.0
 idna==2.10
-immutables==0.19
+immutables==0.21
 importlib-metadata==4.8.3
 itsdangerous==2.0.1
 Jinja2==3.0.3

--- a/src/test/resources/tst_manifests/pip/pip_requirements_txt_no_ignore/expected_component_sbom.json
+++ b/src/test/resources/tst_manifests/pip/pip_requirements_txt_no_ignore/expected_component_sbom.json
@@ -99,10 +99,10 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:pypi/immutables@0.19",
+      "bom-ref" : "pkg:pypi/immutables@0.21",
       "name" : "immutables",
-      "version" : "0.19",
-      "purl" : "pkg:pypi/immutables@0.19"
+      "version" : "0.21",
+      "purl" : "pkg:pypi/immutables@0.21"
     },
     {
       "type" : "library",
@@ -225,7 +225,7 @@
         "pkg:pypi/flask@2.0.3",
         "pkg:pypi/h11@0.13.0",
         "pkg:pypi/idna@2.10",
-        "pkg:pypi/immutables@0.19",
+        "pkg:pypi/immutables@0.21",
         "pkg:pypi/importlib-metadata@4.8.3",
         "pkg:pypi/itsdangerous@2.0.1",
         "pkg:pypi/jinja2@3.0.3",
@@ -288,7 +288,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:pypi/immutables@0.19",
+      "ref" : "pkg:pypi/immutables@0.21",
       "dependsOn" : [ ]
     },
     {

--- a/src/test/resources/tst_manifests/pip/pip_requirements_txt_no_ignore/expected_stack_sbom.json
+++ b/src/test/resources/tst_manifests/pip/pip_requirements_txt_no_ignore/expected_stack_sbom.json
@@ -162,10 +162,10 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:pypi/immutables@0.19",
+      "bom-ref" : "pkg:pypi/immutables@0.21",
       "name" : "immutables",
-      "version" : "0.19",
-      "purl" : "pkg:pypi/immutables@0.19"
+      "version" : "0.21",
+      "purl" : "pkg:pypi/immutables@0.21"
     },
     {
       "type" : "library",
@@ -225,7 +225,7 @@
         "pkg:pypi/flask@2.0.3",
         "pkg:pypi/h11@0.13.0",
         "pkg:pypi/idna@2.10",
-        "pkg:pypi/immutables@0.19",
+        "pkg:pypi/immutables@0.21",
         "pkg:pypi/importlib-metadata@4.8.3",
         "pkg:pypi/itsdangerous@2.0.1",
         "pkg:pypi/jinja2@3.0.3",
@@ -343,7 +343,7 @@
       "dependsOn" : [ ]
     },
     {
-      "ref" : "pkg:pypi/immutables@0.19",
+      "ref" : "pkg:pypi/immutables@0.21",
       "dependsOn" : [ ]
     },
     {

--- a/src/test/resources/tst_manifests/pip/pip_requirements_txt_no_ignore/requirements.txt
+++ b/src/test/resources/tst_manifests/pip/pip_requirements_txt_no_ignore/requirements.txt
@@ -9,7 +9,7 @@ fastapi==0.75.1
 Flask==2.0.3
 h11==0.13.0
 idna==2.10
-immutables==0.19
+immutables==0.21
 importlib-metadata==4.8.3
 itsdangerous==2.0.1
 Jinja2==3.0.3

--- a/src/test/resources/tst_manifests/pip/pipdeptree.json
+++ b/src/test/resources/tst_manifests/pip/pipdeptree.json
@@ -165,7 +165,7 @@
     "package": {
       "key": "immutables",
       "package_name": "immutables",
-      "installed_version": "0.19"
+      "installed_version": "0.21"
     },
     "dependencies": []
   },


### PR DESCRIPTION
chore: update python test dependency immutables to be compatible with higher version python

## Description

`Python_Provider_Test` fails with a higher Python version (3.13) in local.

immutables 0.19 is not compatible with python version. E.g. 3.13. It's only compatible with Python versions until 3.11.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
