### PR TITLE
fix: prefer stdout

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/YarnBerryProcessor.java
+++ b/src/main/java/com/redhat/exhort/providers/YarnBerryProcessor.java
@@ -87,6 +87,7 @@ public final class YarnBerryProcessor extends YarnProcessor {
     return name.endsWith("@workspace:.");
   }
 
+  @Override
   public String parseDepTreeOutput(String output) {
     return "[" + output.trim().replace(System.lineSeparator(), "").replace("}{", "},{") + "]";
   }

--- a/src/main/java/com/redhat/exhort/tools/Operations.java
+++ b/src/main/java/com/redhat/exhort/tools/Operations.java
@@ -165,13 +165,13 @@ public final class Operations {
       }
 
       String stdout = new String(process.getInputStream().readAllBytes());
-      String stderr = new String(process.getErrorStream().readAllBytes());
 
-      // TODO: This should throw an exception if the process fails
-      if (!stderr.isBlank()) {
-        return stderr.trim();
+      if (!stdout.isBlank()) {
+        return stdout.trim();
       }
-      return stdout.trim();
+      // TODO: This should throw an exception if the process fails
+      String stderr = new String(process.getErrorStream().readAllBytes());
+      return stderr.trim();
     } catch (IOException e) {
       throw new RuntimeException(
           String.format("Failed to execute command '%s' ", join(" ", cmdList)), e);


### PR DESCRIPTION
## Description

Prefer stdout over stderr to cover cases when there are only warnings. If only error is present and no stdout is returned then the error will be returned instead.

**Related issue (if any):** fixes #154 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

