### PR TITLE
fix: mvn binary in windows

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/JavaMavenProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaMavenProvider.java
@@ -54,7 +54,7 @@ public final class JavaMavenProvider extends BaseJavaProvider {
   private static final String PROP_JAVA_HOME = "JAVA_HOME";
   private static final Logger log = LoggersFactory.getLogger(JavaMavenProvider.class.getName());
   private final String mvnExecutable;
-  private static final String MVN = "mvn";
+  private static final String MVN = Operations.isWindows() ? "mvn.cmd" : "mvn";
   private static final String ARG_VERSION = "-v";
 
   public JavaMavenProvider(Path manifest) {
@@ -65,7 +65,8 @@ public final class JavaMavenProvider extends BaseJavaProvider {
 
   @Override
   public Content provideStack() throws IOException {
-    var mvnCleanCmd = new String[] {mvnExecutable, "clean", "-f", manifest.toString()};
+    var mvnCleanCmd =
+        new String[] {mvnExecutable, "clean", "-f", manifest.toString(), "--batch-mode", "-q"};
     var mvnEnvs = getMvnExecEnvs();
     // execute the clean command
     Operations.runProcess(manifest.getParent(), mvnCleanCmd, mvnEnvs);
@@ -82,6 +83,8 @@ public final class JavaMavenProvider extends BaseJavaProvider {
             add(String.format("-DoutputFile=%s", tmpFile.toString()));
             add("-f");
             add(manifest.toString());
+            add("--batch-mode");
+            add("-q");
           }
         };
     // if we have dependencies marked as ignored, exclude them from the tree command
@@ -136,7 +139,9 @@ public final class JavaMavenProvider extends BaseJavaProvider {
           "help:effective-pom",
           String.format("-Doutput=%s", tmpEffPom.toString()),
           "-f",
-          manifest.toString()
+          manifest.toString(),
+          "--batch-mode",
+          "-q"
         };
     // execute the effective pom command
     Operations.runProcess(manifest.getParent(), mvnEffPomCmd, getMvnExecEnvs());
@@ -378,7 +383,7 @@ public final class JavaMavenProvider extends BaseJavaProvider {
         try {
           // verify maven wrapper is accessible
           Operations.runProcess(manifest.getParent(), mvnw, ARG_VERSION);
-          log.fine("using maven wrapper from : " + mvnw);
+          log.fine(String.format("using maven wrapper from : %s", mvnw));
           return mvnw;
         } catch (Exception e) {
           log.warning(
@@ -388,7 +393,7 @@ public final class JavaMavenProvider extends BaseJavaProvider {
     }
     // If maven wrapper is not requested or not accessible, fall back to use mvn
     String mvn = Operations.getExecutable(MVN, ARG_VERSION);
-    log.fine("using mvn executable from : " + mvn);
+    log.fine(String.format("using mvn executable from : %s", mvn));
     return mvn;
   }
 


### PR DESCRIPTION
## Description

Use `mvn.cmd` as default binary for windows environments
Use batch-mode for unattended builds and quiet flag to enhance performance

**Related issue (if any):** fixes #158 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
