### PR TITLE
fix: docker and podman are optional for image analysis

### DIFF
--- a/src/main/java/com/redhat/exhort/image/ImageUtils.java
+++ b/src/main/java/com/redhat/exhort/image/ImageUtils.java
@@ -131,8 +131,8 @@ public class ImageUtils {
 
   static Operations.ProcessExecOutput execSyft(ImageRef imageRef) {
     var syft = Operations.getExecutable(SYFT, ARG_VERSION);
-    var docker = Operations.getExecutable(DOCKER, ARG_VERSION);
-    var podman = Operations.getExecutable(PODMAN, ARG_VERSION);
+    var docker = Operations.getCustomPathOrElse(DOCKER);
+    var podman = Operations.getCustomPathOrElse(PODMAN);
 
     var syftConfigPath = Environment.get(EXHORT_SYFT_CONFIG_PATH, "");
     var imageSource = Environment.get(EXHORT_SYFT_IMAGE_SOURCE, "");
@@ -238,7 +238,7 @@ public class ImageUtils {
   }
 
   static String hostInfo(String engine, String info) {
-    var exec = Operations.getExecutable(engine, ARG_VERSION);
+    var exec = Operations.getCustomPathOrElse(engine);
     var cmd = new String[] {exec, "info"};
 
     var output = Operations.runProcessGetFullOutput(null, cmd, null);


### PR DESCRIPTION
## Description

fix: docker and podman are optional for image analysis

>Optionally, set the full path of the Docker or Podman executable. Syft will attempt to find the images in the Docker or Podman daemon with the executable. Otherwise, Syft will try direct remote registry access. 

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.